### PR TITLE
Fixing issue #36. Once body parameter value was set it was never updated with user input.

### DIFF
--- a/src/scripts/swagger-client.js
+++ b/src/scripts/swagger-client.js
@@ -44,7 +44,8 @@ angular
 			var deferred = $q.defer(),
 				query = {},
 				headers = {},
-				path = operation.path;
+				path = operation.path,
+				body = undefined;
 
 			// build request parameters
 			for (var i = 0, params = operation.parameters || [], l = params.length; i < l; i++) {
@@ -67,23 +68,23 @@ angular
 						}
 						break;
 					case 'formData':
-						values.body = values.body || new FormData();
+						body = body || new FormData();
 						if (!!value) {
 							if (param.type === 'file') {
 								values.contentType = undefined; // make browser defining it by himself
 							}
-							values.body.append(param.name, value);
+							body.append(param.name, value);
 						}
 						break;
 					case 'body':
-						values.body = values.body || value;
+						body = body || value;
 						break;
 				}
 			}
 
 			// add headers
 			headers.Accept = values.responseType;
-			headers['Content-Type'] = values.body ? values.contentType : 'text/plain';
+			headers['Content-Type'] = body ? values.contentType : 'text/plain';
 
 			// build request
 			var baseUrl = [
@@ -96,7 +97,7 @@ angular
 					method: operation.httpMethod,
 					url: baseUrl + path,
 					headers: headers,
-					data: values.body,
+					data: body,
 					params: query
 				},
 				callback = function(data, status, headers, config) {


### PR DESCRIPTION
This commit fixed issue described in #36 .
When using swagger client for exploring api there was a problem with sending parameters which were located in request's body. Once the value was set for given operation, it was never updated with user input later. In consequence, user couldn't change input and send request again.
