### PR TITLE
Fixing allOf implementation breaking schema properties.

### DIFF
--- a/src/scripts/swagger-model.js
+++ b/src/scripts/swagger-model.js
@@ -63,11 +63,10 @@ angular
 		 */
 		function resolveAllOf(swagger, schema) {
 			if (schema.allOf) {
-				var newSchema = {};
 				angular.forEach(schema.allOf, function(def) {
-					angular.merge(newSchema, resolveReference(swagger, def));
+					angular.merge(schema, resolveReference(swagger, def));
 				});
-				schema = newSchema;
+				delete schema.allOf;
 			}
 			return schema;
 		}


### PR DESCRIPTION
With the current implementation introduced in 0ad1d1d, a schema using allOf only contains the
properties referenced by allOf while its own properties are lost. This
fix aims at correctly extending the schema with allOf without losing any
properties.
