### PR TITLE
Make a copy of swagger input before modifying it

### DIFF
--- a/src/scripts/swagger-ui.js
+++ b/src/scripts/swagger-ui.js
@@ -161,7 +161,7 @@ angular
 				$scope.resources = [];
 				$scope.form = {};
 				if (data) {
-					swagger = data;
+					swagger = angular.copy(data);
 					swaggerLoaded(null, 'application/' + $scope.inputType);
 				}
 			});


### PR DESCRIPTION
Currently there are modifications being done to the swagger object being supplied via input. This can cause adverse affects if these objects are used outside of the directive. To solve this, make a copy of the swagger object in `watchData()`.

---

For one of our projects, we have several `swagger.json` files. We navigate to each of them (one directive per `swagger.json`), and store a list of the swagger objects. As we switch back and forth between them, the directives get re-initialized with the swagger object that was previously modified. Every re-initialization appends tags and causes the operations in the resources to duplicate (which are then being displayed). By copying the input *before* modifying the tag list, we guarantee to keep the changes isolated.