### PR TITLE
dynamic path building with case sensitive parameters

### DIFF
--- a/src/scripts/swagger-client.js
+++ b/src/scripts/swagger-client.js
@@ -60,7 +60,8 @@ angular
 						}
 						break;
 					case 'path':
-						path = path.replace('{' + param.name + '}', encodeURIComponent(value));
+						var pattern = new RegExp('{' + param.name + '}', 'gi');
+						path = path.replace(pattern, encodeURIComponent(value));
 						break;
 					case 'header':
 						if (!!value) {


### PR DESCRIPTION
dynamic path building with parameters is not working properly due to case sensitive names, it would be more general to ignore characters case in replacing parameters for building a path.