### PR TITLE
External Docs Support

### DIFF
--- a/src/less/swagger-ui.less
+++ b/src/less/swagger-ui.less
@@ -38,7 +38,6 @@
     }
 
     .external-docs{
-        color: #000;
     }
 
     .endpoint{

--- a/src/scripts/i18n/en.js
+++ b/src/scripts/i18n/en.js
@@ -24,6 +24,7 @@ angular
 				endPointExpandOperations: 'Expand operations',
 				operationDeprected: 'Warning: Deprecated',
 				operationImplementationNotes: 'Implementation notes',
+				externalDocs: 'External docs',
 				headers: 'Response headers',
 				headerName: 'Header',
 				headerDescription: 'Description',

--- a/src/scripts/i18n/fr.js
+++ b/src/scripts/i18n/fr.js
@@ -24,6 +24,7 @@ angular
 				endPointExpandOperations: 'Ouvrir les opérations',
 				operationDeprected: 'Attention: Obsolète',
 				operationImplementationNotes: 'Notes d\'implementation',
+				externalDocs: 'Documents externes',
 				headers: 'Entêtes de la réponse',
 				headerName: 'Entêtes',
 				headerDescription: 'Description',

--- a/src/scripts/i18n/jp.js
+++ b/src/scripts/i18n/jp.js
@@ -24,6 +24,7 @@ angular
 				endPointExpandOperations: '機能詳しく説明',
 				operationDeprected: 'ワーニング: 亡くなった機能',
 				operationImplementationNotes: '連携方法説明',
+				externalDocs: '外部ドキュメント',
 				headers: 'レスポンスヘッダ',
 				headerName: 'ヘッダ',
 				headerDescription: '説明',

--- a/src/scripts/swagger-parser.js
+++ b/src/scripts/swagger-parser.js
@@ -75,6 +75,7 @@ angular
 			infos.basePath = swagger.basePath;
 			infos.host = swagger.host;
 			infos.description = trustHtml(infos.description);
+			infos.externalDocs = swagger.externalDocs;
 		}
 
 		/**

--- a/src/templates/operation.html
+++ b/src/templates/operation.html
@@ -13,6 +13,10 @@
 		<h5 swagger-translate="operationImplementationNotes"></h5>
 		<p ng-bind-html="op.description"></p>
 	</div>
+  <div ng-if="op.externalDocs">
+    <h5 swagger-translate="externalDocs"></h5>
+    <a target="_blank" ng-href="{{op.externalDocs.url}}">{{op.externalDocs.description}}</span></a>
+  </div>
     <button ng-if="op.security.length>0" ng-click="auth(op)" class="auth-required" ng-class="{valid:authValid(op)}" title="{{'authRequired'|swaggerTranslate}}">!</button>
 	<form role="form" name="explorerForm" ng-submit="explorerForm.$valid&&submitExplorer(op)">
     	<div ng-if="op.responseClass" class="response">

--- a/src/templates/swagger-ui.html
+++ b/src/templates/swagger-ui.html
@@ -3,6 +3,10 @@
 		<h3 ng-bind="infos.title"></h3>
 	</div>
 	<div class="api-description" ng-bind-html="infos.description"></div>
+	<div class="external-docs" ng-if="infos.externalDocs">
+		<span swagger-translate="externalDocs"></span>
+		<a target="_blank" ng-href="{{infos.externalDocs.url}}">{{infos.externalDocs.description}}</span></a>
+	</div>
 	<div class="api-infos">
 		<div class="api-infos-contact" ng-if="infos.contact">
 			<div ng-if="infos.contact.name" class="api-infos-contact-name"><span swagger-translate="infoContactCreatedBy" swagger-translate-value="infos.contact"></span></div>


### PR DESCRIPTION
Adds support for the [externalDocs](http://swagger.io/specification/#externalDocumentationObject) parameter at the 'swagger' level and the 'operation' level.

The swagger spec also supports it at the 'tag' level and the 'schema'. Please let me know if I should add it in those places. I'm not sure if there is a convenient location for it. Suggestions are welcome.