### PR TITLE
Fix npm module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+src
+grunt

--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
     },
     "engines": {
         "node": ">=0.10.0"
-    }
+    },
+    "main": "dist/scripts/swagger-ui.js"
 }


### PR DESCRIPTION
- Fix 'main' reference to root JavaScript script.
- Don't include src & grunt directory in NPM distribution

For me it was required to add the main entry to make use of your module.
I though let's give back the change.

Thanks for making this module available.
